### PR TITLE
Add issues table to June workshop page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ This website is automatically generated from Markdown files in the `docs/` folde
 To add or modify content on the workshop website, edit the corresponding file in the `docs/` folder.
 
 The site title, Github URL, and other information is set in `docs/_config.yml`, a YAML configuration file.
+

--- a/docs/issues_table.md
+++ b/docs/issues_table.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: June 2018 DCPPC Workshop
+tagline: Agenda Items
+---
+
+| Github Issue Links |
+| ------------------ |
+| [Carry over session proposals from May 2018 Workshop](https://api.github.com/repos/dcppc/2018-june-workshop/issues/11) |
+| [Demo Descriptions and Schedule](https://api.github.com/repos/dcppc/2018-june-workshop/issues/8) |
+| [Breakout group organization](https://api.github.com/repos/dcppc/2018-june-workshop/issues/7) |
+| [Day 2 lightning talks](https://api.github.com/repos/dcppc/2018-june-workshop/issues/5) |
+| [Day 1 lightning talks ](https://api.github.com/repos/dcppc/2018-june-workshop/issues/4) |
+


### PR DESCRIPTION
This is to test a script that programmatically adds an issues table to workshop repos.